### PR TITLE
Add storage cookie setting helpers for path and domain

### DIFF
--- a/generators/php/src/main/resources/php/Sdk/Storage/BaseStorage.mustache
+++ b/generators/php/src/main/resources/php/Sdk/Storage/BaseStorage.mustache
@@ -8,6 +8,8 @@ class BaseStorage
 {
     static $prefix = 'kinde';
     static $storage;
+    private static $cookiePath = "";
+    private static $cookieDomain = "";
 
     static function getStorage()
     {
@@ -26,14 +28,14 @@ class BaseStorage
         string $key,
         string $value,
         int $expires_or_options = 0,
-        string $path = "",
-        string $domain = "",
+        string $path = null,
+        string $domain = null,
         bool $secure = true,
         bool $httpOnly = false
     ) {
         $newKey = self::getKey($key);
         $_COOKIE[$newKey] = $value;
-        setcookie($newKey, $value, $expires_or_options, $path, $domain, $secure, $httpOnly);
+        setcookie($newKey, $value, $expires_or_options, $path ?? self::$cookiePath, $domain ?? self::$cookieDomain, $secure, $httpOnly);
     }
 
     public static function removeItem(string $key)
@@ -57,5 +59,15 @@ class BaseStorage
     private static function getKey($key)
     {
         return self::$prefix . '_' . $key;
+    }
+
+    public static function setCookiePath($cookiePath)
+    {
+        self::$cookiePath = $cookiePath;
+    }
+
+    public static function setCookieDomain($cookieDomain)
+    {
+        self::$cookieDomain = $cookieDomain;
     }
 }

--- a/kinde-mgmt-api-specs.yaml
+++ b/kinde-mgmt-api-specs.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '1.2'
+  version: '1.2.2'
   title: Kinde Management API
   description: Provides endpoints to manage your Kinde Businesses
   termsOfService: https://kinde.com/docs/important-information/terms-of-service/


### PR DESCRIPTION
# Explain your changes

Add storage cookie setting helpers for path and domain. By default the cookie is created for the current domain, at the path where the code is called. These settings allow the cookie to be used from other subdomains, and to set the cookie to the root of the domain regardless of where the code is called from.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
